### PR TITLE
Fixes styling issues.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "hdeem_cxx"]
 	path = hdeem_cxx
-	url = git@github.com:tud-zih-energy/hdeem_cxx.git
+	url = https://github.com/tud-zih-energy/hdeem_cxx.git
 [submodule "common"]
 	path = common
-	url = git@github.com:score-p/scorep_plugin_common.git
+	url = https://github.com/score-p/scorep_plugin_common.git
 [submodule "scorep"]
 	path = scorep
-	url = git@github.com:score-p/scorep_plugin_cxx_wrapper
+	url = https://github.com/score-p/scorep_plugin_cxx_wrapper

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+Thomas Ilsche <thomas.ilsche at tu-dresden dot de>
+Mario Bielert <mario.bielert at tu-dresden dot de>
+Andreas Gocht <andreas.gocht at tu-dresden dot de>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2016, Technische Universität Dresden, Germany
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+    and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+    and the following disclaimer in the documentation and/or other materials provided with the
+    distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+    or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -6,43 +6,64 @@
 
 To compile this plugin, you need:
 
-* C++11 compiler
+* A C++ 11 compiler
 
-* Score-P with SCOREP_METRIC_PLUGIN_VERSION 1
-    Currently this is the branch TRY_RTSCHUETER_plugins_sync_callback
+* Score-P with `SCOREP_METRIC_PLUGIN_VERSION` 1 (Currently this is the branch
+    `TRY_RTSCHUETER_plugins_sync_callback`)
 
-* The HDEEM library and header files by BULL/ATOS
+* The hdeem library and header files by BULL/ATOS
 
 ###Building and installation
 
-1. Invoke CMake
+1. Create a build directory
 
-        mkdir BUILD && cd BUILD
+        mkdir build
+        cd build
+
+2. Invoke CMake
+
         cmake ..
 
-The following settings are important:
+    The following settings are important:
 
-* HDEEM_BMC_USER HDEEM_BMC_PASS   required for out of band access
-* HDEEM_INCLUDE_DIRS              directory where hdeem.h is located
-* HDEEM_LIBRARIES                 the full path of libhdeem.so, including the file name,
-                                  e.g. /usr/local/hdeem/libhdeem.so.1
-* SCOREPPLUGINCXX_INCLUDE_DIRS    directory for the ScoreP C++ abstraction headers
-* SCOREP_CONFIG                   path to the scorep-config tool including the file name
-* CMAKE_INSTALL_PREFIX            directory where the resulting plugin will be installed
-                                  (lib/ suffix will be added)
-* ENABLE_MPI                      [just for the sync plugin] Enables MPI communication for
-                                  the sync plugin, and allows to run more than one MPI
-                                  process per node.
+    * `HDEEM_BMC_USER HDEEM_BMC_PASS`
 
-2. Invoke make
+        Required for out of band access
+
+    * `HDEEM_INCLUDE_DIRS`
+
+        Directory where `hdeem.h` is located
+
+    * `HDEEM_LIBRARIES`
+
+        The full path of `libhdeem.so`, including the file name, e.g. `/usr/local/hdeem/libhdeem.so.1`
+
+    * `SCOREPPLUGINCXX_INCLUDE_DIRS`
+
+        Directory for the Score-P C++ abstraction headers
+
+    * `SCOREP_CONFIG`
+
+        Path to the `scorep-config` tool including the file name
+
+        > *Note:*
+        
+        > If you have `scorep-config` in your `PATH`, it should be found by CMake.
+
+    * `CMAKE_INSTALL_PREFIX`
+
+        Directory where the resulting plugin will be installed (`lib/` suffix will be added)
+
+    * `ENABLE_MPI` (only applicable to the `hdeem_sync_plugin`)
+
+        Enables MPI communication for the sync plugin, and allows to run more than one MPI process
+        per node.
+
+3. Invoke make
 
         make
 
-> *Note:*
-
-> If you have `scorep-config` in your `PATH`, it should be found by CMake.
-
-3. Invoke make
+4. Install the files (optional)
 
         make install
 
@@ -52,84 +73,80 @@ The following settings are important:
 
 ##Usage
 
-To add a dataheap metric to your trace, you have to add `hdeem_plugin` to the environment
-variable `SCOREP_METRIC_PLUGINS`.
+To add a dataheap metric to your trace, you have to add `hdeem_plugin` to the environment variable
+`SCOREP_METRIC_PLUGINS`.
 
-To add the synchrone metric, add `hdeem_sync_plugin` to the environment
-variable `SCOREP_METRIC_PLUGINS`.
+To add the synchrone metric, add `hdeem_sync_plugin` to the environment variable
+`SCOREP_METRIC_PLUGINS`.
 
+You have to add the list of the metric channel you are interested in to the environment variable
+`SCOREP_METRIC_HDEEM_PLUGIN` or `SCOREP_METRIC_HDEEM_SYNC_PLUGIN`.
 
-You have to add the list of the metric channel you are interested in to the environment
-variable `SCOREP_METRIC_HDEEM_PLUGIN` or `SCOREP_METRIC_HDEEM_SYNC_PLUGIN`.
-
-Note: Score-P does not support per-host post-mortem plugins with profiling. If you want to
-use the post-mortem (hdeem_plugin) plugin, you should enable tracing and disable profiling
-by using:
+Note: Score-P does not support per-host post-mortem plugins with profiling. If you want to use the
+post-mortem (`hdeem_plugin`) plugin, you should enable tracing and disable profiling by using:
 
         export SCOREP_ENABLE_PROFILING="false"
         export SCOREP_ENABLE_TRACING="true"
-        
-The sync plugin (hdeem_sync_plugin) works with profiling and tracing.
-        
-Note: The sync plugin is implemented as a stricly syncronus plugin. Therefor, it measures
-per thread. As HDEEM can just be used nodewide, the plguin does some thread and if enabled
-MPI operations in order to obtain the responsible thread and process. The trace file might
-hold some traces that are reported as 0. The profile might report wrong profiling
-statistics. Moreover, the plugin reports mJ and mW as interfer values. This operations
-are necesarry to be compatible with PTF (http://periscope.in.tum.de/)
+
+The sync plugin (`hdeem_sync_plugin`) works with profiling and tracing.
+
+Note: The sync plugin is implemented as a stricly syncronus plugin. Therefor, it measures per
+thread. As hdeem can just be used nodewide, the plguin does some thread and if enabled MPI
+operations in order to obtain the responsible thread and process. The trace file might hold some
+traces that are reported as 0. The profile might report wrong profiling statistics. Moreover, the
+plugin reports mJ and mW as interfer values. This operations are necesarry to be compatible with PTF
+(http://periscope.in.tum.de/)
 
 ###Environment variables
 
-* `SCOREP_METRIC_HDEEM_PLUGIN` 
+* `SCOREP_METRIC_HDEEM_PLUGIN` (only applicable to the `hdeem_plugin`)
 
     Comma-separated list of sensors, can also contain wildcards, e.g. `Blade,CPU*`
-    [Just for hdeem_plugin]
-    
-* `SCOREP_METRIC_HDEEM_SYNC_PLUGIN`
-    
-    Comma-separated list of sensors, and physical quantity. Can also contain wildcards,
-    e.g. `BLADE/P,*/E` 
-    [Just for hdeem_sync_plugin]
-    
 
-* `SCOREP_METRIC_HDEEM_PLUGIN_CONNECTION` or `SCOREP_METRIC_HDEEM_SYNC_PLUGIN_CONNECTION` 
+* `SCOREP_METRIC_HDEEM_SYNC_PLUGIN` (only applicable to the `hdeem_sync_plugin`)
+    
+    Comma-separated list of sensors, and physical quantity. Can also contain wildcards, e.g.
+    `BLADE/P,*/E`
 
-    Can be set to either `INBAND` for inband connection to the BMC via PCIe/GPIO (default)
-    or `OOB` for out-of-band connection via out-of-band / side-band IPMI.
+* `SCOREP_METRIC_HDEEM_PLUGIN_CONNECTION` or `SCOREP_METRIC_HDEEM_SYNC_PLUGIN_CONNECTION` (defualt
+    `BMC`)
+
+    Can be set to either `INBAND` for inband connection to the BMC via PCIe/GPIO (default) or `OOB`
+    for out-of-band connection via out-of-band / side-band IPMI.
+
     It is recommended to use `INBAND` as it is faster and has better time synchronization.
 
-* `SCOREP_METRIC_HDEEM_PLUGIN_VERBOSE` or `SCOREP_METRIC_HDEEM_SYNC_PLUGIN_VERBOSE` 
+* `SCOREP_METRIC_HDEEM_PLUGIN_VERBOSE` or `SCOREP_METRIC_HDEEM_SYNC_PLUGIN_VERBOSE` (default `WARN`)
 
-    Controls the output verbosity of the plugin. Possible values are:
-    `FATAL`, `ERROR`, `WARN` (default), `INFO`, `DEBUG`, `TRACE` (`TRACE` currently not used)
-    If set to any other value, DEBUG is used. Case in-sensitive.
+    Controls the output verbosity of the plugin. Possible values are: `FATAL`, `ERROR`, `WARN`,
+    `INFO`, `DEBUG`, `TRACE` (`TRACE` currently not used). If set to any other value, `DEBUG` is
+    used. Case in-sensitive.
 
-* `SCOREP_METRIC_HDEEM_PLUGIN_TIMER`
+* `SCOREP_METRIC_HDEEM_PLUGIN_TIMER` (only applicable to the `hdeem_plugin`, default `BMC`)
 
-    Can be set to either `BMC` (default) for using the timestamps from the BMC
-    or `NODE` to use the timestamps of the node. `BMC` is usually much better.
-    [Just for hdeem_plugin]
-    
-* `SCOREP_METRIC_HDEEM_SYNC_PLUGIN_STATS_TIMEOUT_MS`
+    Can be set to either `BMC` for using the timestamps from the BMC or `NODE` to use the timestamps
+    of the node. `BMC` is usually much better.
 
-    Can be set to any integer variable. Defines the time in milliseconds after a
-    hdeem_get_stats become invalid. The measurement of energy or power values might be at
-    any time point since the event to this time. Default is 10 ms.
-    [Just for hdeem_sync_plugin]
+* `SCOREP_METRIC_HDEEM_SYNC_PLUGIN_STATS_TIMEOUT_MS` (only applicable to the `hdeem_sync_plugin`,
+    default `10`)
+
+    Can be set to any integer variable. Defines the time in milliseconds after a `hdeem_get_stats`
+    becomes invalid. The measurement of energy or power values might be at any time point since the
+    event to this time.
 
 
 ###If anything fails:
 
 1. Check whether the plugin library can be loaded from the `LD_LIBRARY_PATH`.
 
-2. Check whether your HDEEM functionality is working properly by using the HDEEM command line tools.
+2. Check whether your hdeem functionality is working properly by using the hdeem command line tools.
 
 3. Write a mail to the author.
 
-### About hdeem_cxx.hpp
+### About `hdeem_cxx.hpp`
 
-The hdeem_cxx.hpp contains a convenient wrapper around hdeem for access with C++.
-See the example/hdeem_cxx.cpp on how to use it or run doxygen in the include directory.
+The `hdeem_cxx.hpp` contains a convenient wrapper around hdeem for access with C++. See the
+`example/hdeem_cxx.cpp` on how to use it or run doxygen in the include directory.
 
 ##Authors
 

--- a/hdeem_plugin.cpp
+++ b/hdeem_plugin.cpp
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ *    and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #define ENV_CONFIG_PREFIX "SCOREP_METRIC_HDEEM_PLUGIN_"
 #include <scorep/plugin/plugin.hpp>
 #include <scorep/plugin/util/matcher.hpp>

--- a/hdeem_sync_plugin.cpp
+++ b/hdeem_sync_plugin.cpp
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ *    and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 // Must be defined before the include!
 #define ENV_CONFIG_PREFIX "SCOREP_METRIC_HDEEM_SYNC_PLUGIN_"
 #include <scorep/plugin/plugin.hpp>


### PR DESCRIPTION
- Small corrections to `README.md`, mainly wrong indentation and some missing ``s.
- `AUTHORS` file added as needed by the Score-P plugin style guide.
- Same for `LICENSE` file.
- License header added to source files.
- License set to 3-clause BSD as for all Score-P plugins.
- Git module inclusion switched to https as this is probably the more common way to
  checkout git repositories.

Please review and give feedback.
